### PR TITLE
Integration de l'enumération pour l'etat des todos

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -69,9 +69,9 @@ class TodoListScreen extends StatelessWidget {
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceAround,
                   children: [
-                    _buildFilterButton(context, 'all', 'Tous'),
-                    _buildFilterButton(context, 'completed', 'Complètes'),
-                    _buildFilterButton(context, 'incomplete', 'Incomplètes'),
+                    _buildFilterButton(context, TodoStatus.all, 'Tous'),
+                    _buildFilterButton(context, TodoStatus.completed, 'Complètes'),
+                    _buildFilterButton(context, TodoStatus.incomplete, 'Incomplètes'),
                   ],
                 ),
               ),
@@ -142,7 +142,7 @@ class TodoListScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildFilterButton(BuildContext context, String filterValue, String label) {
+  Widget _buildFilterButton(BuildContext context, TodoStatus filterValue, String label) {
     final todoProvider = Provider.of<TodoProvider>(context);
     final isSelected = todoProvider.filter == filterValue;
 
@@ -200,23 +200,25 @@ class TodoListScreen extends StatelessWidget {
   }
 }
 
+enum TodoStatus { all, completed, incomplete }
+
 class TodoProvider extends ChangeNotifier {
   final List<TodoItem> _todos = [];
-  String _filter = 'all';
+  TodoStatus _filter = TodoStatus.all;
   final TextEditingController _controller = TextEditingController();
 
   TextEditingController get controller => _controller;
 
   List<TodoItem> get filteredTodos {
-    if (_filter == 'completed') {
+    if (_filter == TodoStatus.completed) {
       return _todos.where((todo) => todo.isDone).toList();
-    } else if (_filter == 'incomplete') {
+    } else if (_filter == TodoStatus.incomplete) {
       return _todos.where((todo) => !todo.isDone).toList();
     }
     return _todos;
   }
 
-  String get filter => _filter;
+  TodoStatus get filter => _filter;
 
   TodoProvider() {
     _loadTodos();
@@ -243,7 +245,7 @@ class TodoProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  void setFilter(String filter) {
+  void setFilter(TodoStatus filter) {
     _filter = filter;
     notifyListeners();
   }


### PR DESCRIPTION
Cette PR introduit l'intégration d'une énumération `TodoStatus` pour mieux gérer l'état des éléments de la liste de tâches.
Proposition lié à cette demande: https://github.com/alexyvanot/flutter_todo_list/pull/1#discussion_r1798537067
Voici les principales modifications apportées :

- **Énumération `TodoStatus` :** Une nouvelle énumération a été ajoutée, comprenant trois états : `all`, `completed`, et `incomplete`. Cela permet une gestion plus claire et typée des filtres appliqués à la liste de tâches.
  
- **Mise à jour des filtres :** Les méthodes et widgets utilisant les filtres ont été ajustés pour utiliser l'énumération `TodoStatus` au lieu de chaînes de caractères. Cela améliore la lisibilité et la sécurité du code.

- **Refactorisation de `_buildFilterButton` :** La méthode `_buildFilterButton` a été modifiée pour accepter un paramètre de type `TodoStatus` au lieu de `String`, ce qui facilite l'utilisation des filtres définis par l'énumération.

- **Modification dans `TodoProvider` :** Les propriétés de filtrage et les méthodes associées ont été mises à jour pour utiliser le nouveau type `TodoStatus`, ce qui garantit une cohérence dans le filtrage des tâches.
